### PR TITLE
Removing Outliers

### DIFF
--- a/data/raw/ttc_delay_outliers_cleaning.ipynb
+++ b/data/raw/ttc_delay_outliers_cleaning.ipynb
@@ -1,0 +1,472 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3766ee6a",
+   "metadata": {},
+   "source": [
+    "# TTC Subway Delay Data (2025): Cleaning + Outlier Removal (MAD)\n",
+    "\n",
+    "This notebook implements a reproducible preprocessing pipeline for `ttc-subway-delay-data-2025.csv`:\n",
+    "\n",
+    "1. Inspect raw categorical values (`Line`, `Bound`) before designing mappings.\n",
+    "2. Remove invalid rows first: any row where `Min Delay` or `Min Gap` is **missing**, **non-numeric**, or equals **0**.\n",
+    "3. Canonicalize:\n",
+    "   - `Line` → `Line_clean` (supports combinations like `YU/BD`)\n",
+    "   - `Bound` → `Bound_clean` (maps `N`, `NB`, `NORTH` → `N`, etc.)\n",
+    "4. Detect and drop outliers using a robust z-score based on **MAD (Median Absolute Deviation)**, computed per `Line_clean`.\n",
+    "5. Produce a statistical report comparing distributions before vs after outlier removal.\n",
+    "6. Save a cleaned CSV keeping original column order, plus:\n",
+    "   - `Bound_clean` as **second-to-last**\n",
+    "   - `Line_clean` as **last**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c464acc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04380c7b",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53705641",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FILE_PATH = \"TTC Subway Delay Data since 2025.csv\"\n",
+    "OUT_PATH = \"TTC Subway Delay Data since 2025_cleaned.csv\"\n",
+    "Z_THRESH = 6.0\n",
+    "\n",
+    "# If True: raise if unexpected raw Bound formats appear after normalization\n",
+    "STRICT_RAW_BOUND_VALIDATION = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4e7a08f",
+   "metadata": {},
+   "source": [
+    "## 1) Load + Inspect Raw Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b71517b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original dataset shape: (28191, 11)\n",
+      "\n",
+      "--- RAW CATEGORICAL INSPECTION ---\n",
+      "\n",
+      "Raw Line (top 20 counts incl NaN):\n",
+      "Line\n",
+      "YU              14358\n",
+      "BD              12216\n",
+      "SHP              1150\n",
+      "YU/BD             348\n",
+      "NaN                75\n",
+      "YUS/BD             16\n",
+      "YUS                 5\n",
+      "BD/YU               4\n",
+      "YU/ BD              3\n",
+      "BD/YUS              3\n",
+      "YU / BD             2\n",
+      "SRT                 2\n",
+      "YUS / BD            2\n",
+      "YU/BD LINES         2\n",
+      "YUS/ BD             1\n",
+      "YUS/ BD/ SHP        1\n",
+      "YU/BD/SHP           1\n",
+      "YU -BD LINES        1\n",
+      "29 DUFFERIN         1\n",
+      "Name: count, dtype: int64\n",
+      "\n",
+      "Raw Bound (top 20 counts incl NaN):\n",
+      "Bound\n",
+      "NaN    10230\n",
+      "S       4831\n",
+      "E       4576\n",
+      "W       4277\n",
+      "N       4251\n",
+      "B         26\n",
+      "Name: count, dtype: int64\n",
+      "\n",
+      "WARNING: Unexpected RAW Bound values found (normalized): ['B']\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_raw = pd.read_csv(FILE_PATH)\n",
+    "print(\"Original dataset shape:\", df_raw.shape)\n",
+    "\n",
+    "print(\"\\n--- RAW CATEGORICAL INSPECTION ---\")\n",
+    "print(\"\\nRaw Line (top 20 counts incl NaN):\")\n",
+    "print(df_raw[\"Line\"].value_counts(dropna=False).head(20))\n",
+    "\n",
+    "print(\"\\nRaw Bound (top 20 counts incl NaN):\")\n",
+    "print(df_raw[\"Bound\"].value_counts(dropna=False).head(20))\n",
+    "\n",
+    "# Validation of raw Bound formats (normalized)\n",
+    "raw_bound_norm = df_raw[\"Bound\"].astype(str).str.strip().str.upper()\n",
+    "raw_bound_norm = raw_bound_norm.where(~df_raw[\"Bound\"].isna(), other=np.nan)\n",
+    "\n",
+    "allowed_raw_bound = {\"N\", \"S\", \"E\", \"W\", \"NB\", \"SB\", \"EB\", \"WB\", \"NORTH\", \"SOUTH\", \"EAST\", \"WEST\"}\n",
+    "unexpected_raw_bound = sorted(set(raw_bound_norm.dropna().unique()) - allowed_raw_bound)\n",
+    "\n",
+    "if unexpected_raw_bound:\n",
+    "    msg = f\"\\nWARNING: Unexpected RAW Bound values found (normalized): {unexpected_raw_bound}\"\n",
+    "    if STRICT_RAW_BOUND_VALIDATION:\n",
+    "        raise ValueError(msg)\n",
+    "    else:\n",
+    "        print(msg)\n",
+    "\n",
+    "df = df_raw.copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb6ddb24",
+   "metadata": {},
+   "source": [
+    "## 2) Remove zero / missing / non-numeric rows FIRST (`Min Delay`, `Min Gap`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "55a12883",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "After removing zero/missing/non-numeric (Min Delay/Min Gap): (9530, 11) (dropped 18661)\n"
+     ]
+    }
+   ],
+   "source": [
+    "df[\"Min Delay\"] = pd.to_numeric(df[\"Min Delay\"], errors=\"coerce\")\n",
+    "df[\"Min Gap\"]   = pd.to_numeric(df[\"Min Gap\"], errors=\"coerce\")\n",
+    "\n",
+    "before_n = len(df)\n",
+    "df = df.dropna(subset=[\"Min Delay\", \"Min Gap\"])\n",
+    "df = df[(df[\"Min Delay\"] > 0) & (df[\"Min Gap\"] > 0)]\n",
+    "after_n = len(df)\n",
+    "\n",
+    "print(\"\\nAfter removing zero/missing/non-numeric (Min Delay/Min Gap):\", df.shape, f\"(dropped {before_n - after_n})\")\n",
+    "\n",
+    "# Validations\n",
+    "assert df[\"Min Delay\"].notna().all() and df[\"Min Gap\"].notna().all(), \"Unexpected NaNs remain in Min Delay/Min Gap.\"\n",
+    "assert (df[\"Min Delay\"] > 0).all() and (df[\"Min Gap\"] > 0).all(), \"Zeros/negatives remain in Min Delay/Min Gap.\" "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3b1cfea",
+   "metadata": {},
+   "source": [
+    "## 3) Canonicalize `Line` and `Bound`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c709ad4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- CANONICALIZED CATEGORICAL INSPECTION ---\n",
+      "\n",
+      "Line_clean counts:\n",
+      "Line_clean\n",
+      "YU         5217\n",
+      "BD         3946\n",
+      "SHP         366\n",
+      "UNKNOWN       1\n",
+      "Name: count, dtype: int64\n",
+      "\n",
+      "Bound_clean counts:\n",
+      "Bound_clean\n",
+      "S          2808\n",
+      "N          2352\n",
+      "E          2220\n",
+      "W          2061\n",
+      "UNKNOWN      89\n",
+      "Name: count, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "def canonical_line(x):\n",
+    "    if pd.isna(x):\n",
+    "        return \"UNKNOWN\"\n",
+    "\n",
+    "    s = str(x).upper().replace(\" \", \"\")\n",
+    "\n",
+    "    present = set()\n",
+    "    if \"YU\" in s:\n",
+    "        present.add(\"YU\")\n",
+    "    if \"BD\" in s:\n",
+    "        present.add(\"BD\")\n",
+    "    if \"SHP\" in s:\n",
+    "        present.add(\"SHP\")\n",
+    "    if \"SRT\" in s:\n",
+    "        present.add(\"SRT\")\n",
+    "\n",
+    "    order = [\"YU\", \"BD\", \"SHP\", \"SRT\"]\n",
+    "    tokens = [t for t in order if t in present]\n",
+    "\n",
+    "    return \"/\".join(tokens) if tokens else \"UNKNOWN\"\n",
+    "\n",
+    "\n",
+    "def canonical_bound(x):\n",
+    "    if pd.isna(x):\n",
+    "        return \"UNKNOWN\"\n",
+    "\n",
+    "    s = str(x).strip().upper()\n",
+    "\n",
+    "    mapping = {\n",
+    "        \"N\": \"N\", \"NB\": \"N\", \"NORTH\": \"N\",\n",
+    "        \"S\": \"S\", \"SB\": \"S\", \"SOUTH\": \"S\",\n",
+    "        \"E\": \"E\", \"EB\": \"E\", \"EAST\": \"E\",\n",
+    "        \"W\": \"W\", \"WB\": \"W\", \"WEST\": \"W\",\n",
+    "    }\n",
+    "    return mapping.get(s, \"UNKNOWN\")\n",
+    "\n",
+    "\n",
+    "df[\"Line_clean\"] = df[\"Line\"].apply(canonical_line)\n",
+    "df[\"Bound_clean\"] = df[\"Bound\"].apply(canonical_bound)\n",
+    "\n",
+    "print(\"\\n--- CANONICALIZED CATEGORICAL INSPECTION ---\")\n",
+    "print(\"\\nLine_clean counts:\")\n",
+    "print(df[\"Line_clean\"].value_counts(dropna=False))\n",
+    "\n",
+    "print(\"\\nBound_clean counts:\")\n",
+    "print(df[\"Bound_clean\"].value_counts(dropna=False))\n",
+    "\n",
+    "# Validation: Bound_clean must be in allowed set\n",
+    "allowed_bound_clean = {\"N\", \"S\", \"E\", \"W\", \"UNKNOWN\"}\n",
+    "bad_bound_clean = sorted(set(df[\"Bound_clean\"].dropna().unique()) - allowed_bound_clean)\n",
+    "assert not bad_bound_clean, f\"Unexpected Bound_clean values: {bad_bound_clean}\"\n",
+    "\n",
+    "# Validation: Line_clean must be UNKNOWN or a valid slash-join of allowed tokens in canonical order\n",
+    "allowed_tokens = [\"YU\", \"BD\", \"SHP\", \"SRT\"]\n",
+    "allowed_line_clean = {\"UNKNOWN\"}\n",
+    "for r in range(1, 1 << len(allowed_tokens)):\n",
+    "    combo = [allowed_tokens[i] for i in range(len(allowed_tokens)) if (r >> i) & 1]\n",
+    "    allowed_line_clean.add(\"/\".join(combo))\n",
+    "\n",
+    "bad_line_clean = sorted(set(df[\"Line_clean\"].dropna().unique()) - allowed_line_clean)\n",
+    "assert not bad_line_clean, f\"Unexpected Line_clean values: {bad_line_clean}\"\n",
+    "\n",
+    "# Snapshot AFTER canonicalization, BEFORE outlier removal (for reporting)\n",
+    "df_before_outliers = df.copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35323595",
+   "metadata": {},
+   "source": [
+    "## 4) Outlier Detection with MAD (per `Line_clean`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6e5724ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Rows flagged as outliers: 376\n",
+      "Final cleaned dataset shape: (9154, 13)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def mad_outlier_mask(series: pd.Series, z_thresh: float = Z_THRESH) -> pd.Series:\n",
+    "    x = series.to_numpy(dtype=float)\n",
+    "    med = np.median(x)\n",
+    "    mad = np.median(np.abs(x - med))\n",
+    "\n",
+    "    if mad == 0 or np.isnan(mad):\n",
+    "        return pd.Series(False, index=series.index)\n",
+    "\n",
+    "    robust_z = 0.6745 * (x - med) / mad\n",
+    "    return pd.Series(np.abs(robust_z) > z_thresh, index=series.index)\n",
+    "\n",
+    "\n",
+    "out_delay = df.groupby(\"Line_clean\")[\"Min Delay\"].transform(lambda s: mad_outlier_mask(s, z_thresh=Z_THRESH))\n",
+    "out_gap   = df.groupby(\"Line_clean\")[\"Min Gap\"].transform(lambda s: mad_outlier_mask(s, z_thresh=Z_THRESH))\n",
+    "\n",
+    "mask_outlier = out_delay | out_gap\n",
+    "print(\"\\nRows flagged as outliers:\", int(mask_outlier.sum()))\n",
+    "\n",
+    "df_clean = df.loc[~mask_outlier].copy()\n",
+    "print(\"Final cleaned dataset shape:\", df_clean.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00b5f267",
+   "metadata": {},
+   "source": [
+    "## 5) Statistical Report: Distribution Changes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0606ba3d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Distribution Report: Min Delay ===\n",
+      "            Before        After   % Change\n",
+      "count  9530.000000  9154.000000  -3.945435\n",
+      "mean      7.843547     5.853725 -25.368900\n",
+      "std      20.739775     3.716301 -82.081284\n",
+      "min       2.000000     2.000000   0.000000\n",
+      "50%       5.000000     5.000000   0.000000\n",
+      "90%      13.000000    11.000000 -15.384615\n",
+      "95%      19.000000    15.000000 -21.052632\n",
+      "99%      50.000000    20.000000 -60.000000\n",
+      "max     900.000000    22.000000 -97.555556\n",
+      "\n",
+      "=== Distribution Report: Min Gap ===\n",
+      "            Before        After   % Change\n",
+      "count  9530.000000  9154.000000  -3.945435\n",
+      "mean     11.889717     9.871641 -16.973288\n",
+      "std      20.857685     4.077746 -80.449673\n",
+      "min       2.000000     2.000000   0.000000\n",
+      "50%       9.000000     9.000000   0.000000\n",
+      "90%      18.000000    16.000000 -11.111111\n",
+      "95%      24.000000    19.000000 -20.833333\n",
+      "99%      54.000000    24.000000 -55.555556\n",
+      "max     906.000000    27.000000 -97.019868\n",
+      "\n",
+      "=== Mean Delay per Line (Before vs After) ===\n",
+      "              Before     After   % Change\n",
+      "Line_clean                               \n",
+      "BD          7.654080  5.751922 -24.851563\n",
+      "SHP         8.262295  5.977401 -27.654470\n",
+      "UNKNOWN     3.000000  3.000000   0.000000\n",
+      "YU          7.958405  5.922006 -25.588037\n"
+     ]
+    }
+   ],
+   "source": [
+    "def distribution_report(df1: pd.DataFrame, df2: pd.DataFrame, col: str) -> None:\n",
+    "    print(f\"\\n=== Distribution Report: {col} ===\")\n",
+    "    stats = pd.DataFrame({\n",
+    "        \"Before\": df1[col].describe(percentiles=[0.5, 0.9, 0.95, 0.99]),\n",
+    "        \"After\":  df2[col].describe(percentiles=[0.5, 0.9, 0.95, 0.99]),\n",
+    "    })\n",
+    "    pct = (stats[\"After\"] - stats[\"Before\"]) / stats[\"Before\"].replace(0, np.nan) * 100\n",
+    "    stats[\"% Change\"] = pct\n",
+    "    print(stats)\n",
+    "\n",
+    "distribution_report(df_before_outliers, df_clean, \"Min Delay\")\n",
+    "distribution_report(df_before_outliers, df_clean, \"Min Gap\")\n",
+    "\n",
+    "print(\"\\n=== Mean Delay per Line (Before vs After) ===\")\n",
+    "mean_compare = pd.DataFrame({\n",
+    "    \"Before\": df_before_outliers.groupby(\"Line_clean\")[\"Min Delay\"].mean(),\n",
+    "    \"After\":  df_clean.groupby(\"Line_clean\")[\"Min Delay\"].mean(),\n",
+    "})\n",
+    "mean_compare[\"% Change\"] = (mean_compare[\"After\"] - mean_compare[\"Before\"]) / mean_compare[\"Before\"].replace(0, np.nan) * 100\n",
+    "print(mean_compare.sort_index())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60baec22",
+   "metadata": {},
+   "source": [
+    "## 6) Column Order + Save\n",
+    "\n",
+    "Keep original column order and append `Bound_clean` (second-to-last) and `Line_clean` (last).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "66450168",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Saved: TTC Subway Delay Data since 2025_cleaned.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "original_cols = list(df_raw.columns)\n",
+    "df_clean = df_clean[original_cols + [\"Bound_clean\", \"Line_clean\"]]\n",
+    "\n",
+    "assert df_clean.columns[-2] == \"Bound_clean\"\n",
+    "assert df_clean.columns[-1] == \"Line_clean\"\n",
+    "\n",
+    "df_clean.to_csv(OUT_PATH, index=False)\n",
+    "print(\"\\nSaved:\", OUT_PATH)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "c8ml7-env (3.11.14)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hello everyone,
I’ve prepared a Jupyter notebook that:
1. Inspects raw categorical values of columns “Bound” and “Line” before designing mappings.
2. Removes invalid rows first. (Any row where “Min Delay” or “Min Gap” is missing, non-numeric, or equals to 0 is considered an invalid row.)
3. Canonicalizes:
   - “Line” to “Line_clean” (supports combinations like “YU/BD”)
   - “Bound” to “Bound_clean” (maps “N”, “NB”, “NORTH”  to “N”, etc.)
4. Detects and drops outliers using a robust z-score based on MAD (Median Absolute Deviation), computed per “Line_clean”.
5. Produces a statistical report comparing distributions before vs after outlier removal.
6. Saves a cleaned CSV keeping original column order, plus:
   - “Bound_clean” as the second-to-last column
   - “Line_clean” as the last column

Please take a look when you have a moment and let me know if you see anything that should be improved or adjusted. Thank you,
Kamran